### PR TITLE
Fix issue with indy_config.py configuration.

### DIFF
--- a/ansible/indy_node/roles/indy_node/tasks/configure.yml
+++ b/ansible/indy_node/roles/indy_node/tasks/configure.yml
@@ -36,6 +36,13 @@
 # =========================================================================================
 # Node Configuration
 # -----------------------------------------------------------------------------------------
+
+- name: "Check if indy_config.py exists"
+  stat:
+    path: /etc/indy/indy_config.py
+  register: indy_config
+
+
 - name: Configure indy_config.py
   template:
     src: indy_config.j2
@@ -43,6 +50,7 @@
     owner: indy
     group: indy
   become: true
+  when: not indy_config.stat.exists
 
 # Note: The '/var/log/indy/{{ network_name }}' folder gets created automatically when indy is started
 - name: Ensure network folder exists


### PR DESCRIPTION
- Ansible scripts were replacing this file with the template on each run.
  - indy-node packages such as sovrin write to this file after it's creation.
  - If this file is then replaced with the base template the added info is essentially deleted, causing issues with things like upgrades.
- Make sure the file is only updated by the Ansible scripts once.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>