### PR TITLE
Adding default indy_plenum_pkg_version variable

### DIFF
--- a/ansible/indy_node/roles/indy_node/defaults/main.yml
+++ b/ansible/indy_node/roles/indy_node/defaults/main.yml
@@ -2,6 +2,7 @@
 indy_node_channel: rc
 indy_node_pkg: indy-node
 indy_node_pkg_version: 1.13.2~rc3
+indy_plenum_pkg_version: 1.13.1~rc2
 
 # Configuration Parameters
 cloud: azure


### PR DESCRIPTION
Adding a default version of the indy_plenum_pkg_version variable to ansible/indy_node/roles/indy_node/defaults/main.yml file. Currently, if not specified, the playbook will fall back to the indy_node_pkg_version and may fail if there is no matching indy plenum version.